### PR TITLE
Harden sync test

### DIFF
--- a/.github/scripts/check-mcp-sync.js
+++ b/.github/scripts/check-mcp-sync.js
@@ -92,28 +92,29 @@ function scanCurrentRepo() {
  * Parse TypeScript file content to extract designSystemData object
  */
 function parseTypeScriptMetadata(content) {
+  const vm = require('vm');
+  let dataString = '';
   try {
     // Find the designSystemData export
     const dataMatch = content.match(/export const designSystemData[\s\S]*?= ([\s\S]*?);\s*$/m);
     if (!dataMatch) {
       throw new Error('Could not find designSystemData export in TypeScript file');
     }
-    
-    let dataString = dataMatch[1];
-    
-    // Clean up the TypeScript syntax to make it valid JSON
-    // Remove TypeScript type annotations and trailing commas
-    dataString = dataString
-      .replace(/([a-zA-Z_$][a-zA-Z0-9_$]*)(\s*):/g, '"$1":') // Quote property names
-      .replace(/'/g, '"') // Convert single quotes to double quotes
-      .replace(/,\s*}/g, '}') // Remove trailing commas before closing braces
-      .replace(/,\s*]/g, ']'); // Remove trailing commas before closing brackets
-    
-    // Parse as JSON
-    const parsedData = JSON.parse(dataString);
+
+    dataString = dataMatch[1];
+
+    // Use vm.runInNewContext for safer evaluation with restricted context
+    // This prevents access to global objects and system functions
+    const context = {};
+    const parsedData = vm.runInNewContext('(' + dataString + ')', context, {
+      timeout: 1000 // 1 second timeout
+    });
     return parsedData;
   } catch (error) {
     console.error('Error parsing TypeScript metadata:', error);
+    if (dataString) {
+      console.error('Failed to parse this data string:', dataString.substring(0, 500) + '...');
+    }
     throw new Error(`Failed to parse MCP server metadata: ${error.message}`);
   }
 }

--- a/.github/scripts/check-mcp-sync.js
+++ b/.github/scripts/check-mcp-sync.js
@@ -78,7 +78,7 @@ function scanCurrentRepo() {
           structure[category][key] = {
             title: title || generateTitleFromFilename(key),
             body: description || `${CATEGORIES[category]} guidance.`,
-            filePath: `${category}/${file}`
+            filePath: `docs/${category}/${file}`
           };
         }
       });

--- a/.github/workflows/sync-mcp-metadata.yml
+++ b/.github/workflows/sync-mcp-metadata.yml
@@ -1,8 +1,9 @@
 name: Check MCP Server Sync
 
 on:
-  # Run on file changes in documentation directories
+  # Run on merges to main branch with documentation changes
   push:
+    branches: [main]
     paths:
       - 'docs/branding/**/*.md'
       - 'docs/components/**/*.md'


### PR DESCRIPTION
# Pull Request

## Description

This a follow up to #142. It makes sure the `docs/` directory is included in the filePath content that gets written to the GitHub Issue. It also fixes a parsing issue with reading the content from the data file from the mcp server.

## Related Issue

n/a

## Type of Change

Please delete options that are not relevant:

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

Please describe the changes made in this PR:

- add docs to path
- change parsing from regex to "virtual machine" approach

## Testing

Please describe how you tested your changes:

- tests pass when running locally
- we'll have to see whether it works when running as a GH Action